### PR TITLE
Cache dependencies in pre-commit github action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,12 @@ jobs:
         run: |
           pip install --constraint=.github/workflows/constraints.txt poetry
 
+      - name: Enable caching
+        uses: actions/cache@v2.1.5
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+
       - name: Install Python modules
         run: |
           poetry install


### PR DESCRIPTION
## :notebook: Summary

This adds a cache step to speed up github action execution.

closes #15 