### PR TITLE
Add additional entities and units

### DIFF
--- a/custom_components/rct_power/lib/entities.py
+++ b/custom_components/rct_power/lib/entities.py
@@ -325,6 +325,21 @@ inverter_sensor_entity_descriptions: List[RctPowerSensorEntityDescription] = [
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     RctPowerSensorEntityDescription(
+        key="g_sync.p_ac_sc[0]",
+        name="Grid Power P1",
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    RctPowerSensorEntityDescription(
+        key="g_sync.p_ac_sc[1]",
+        name="Grid Power P2",
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    RctPowerSensorEntityDescription(
+        key="g_sync.p_ac_sc[2]",
+        name="Grid Power P3",
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    RctPowerSensorEntityDescription(
         key="rb485.f_grid[0]",
         name="Grid Frequency P1",
         state_class=STATE_CLASS_MEASUREMENT,

--- a/custom_components/rct_power/lib/entities.py
+++ b/custom_components/rct_power/lib/entities.py
@@ -257,6 +257,11 @@ inverter_sensor_entity_descriptions: List[RctPowerSensorEntityDescription] = [
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     RctPowerSensorEntityDescription(
+        key="is_struct.Riso",
+        name="Total Insulation Resistance",
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    RctPowerSensorEntityDescription(
         key="inverter_sn",
         name="Inverter Serial Number",
         update_priority=EntityUpdatePriority.STATIC,

--- a/custom_components/rct_power/lib/entities.py
+++ b/custom_components/rct_power/lib/entities.py
@@ -257,8 +257,23 @@ inverter_sensor_entity_descriptions: List[RctPowerSensorEntityDescription] = [
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     RctPowerSensorEntityDescription(
-        key="is_struct.Riso",
-        name="Total Insulation Resistance",
+        key="iso_struct.Riso",
+        name="Insulation Resistance",
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    RctPowerSensorEntityDescription(
+        key="iso_struct.r_min",
+        name="Minimum Insulation Resistance",
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    RctPowerSensorEntityDescription(
+        key="iso_struct.Rn",
+        name="Insulation Resistance Negative Input",
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    RctPowerSensorEntityDescription(
+        key="iso_struct.Rp",
+        name="Insulation Resistance Positive Input",
         state_class=STATE_CLASS_MEASUREMENT,
     ),
     RctPowerSensorEntityDescription(

--- a/custom_components/rct_power/lib/entities.py
+++ b/custom_components/rct_power/lib/entities.py
@@ -280,16 +280,19 @@ inverter_sensor_entity_descriptions: List[RctPowerSensorEntityDescription] = [
         key="g_sync.p_ac[0]",
         name="Inverter Power P1",
         state_class=STATE_CLASS_MEASUREMENT,
+        unit_of_measurement="W",
     ),
     RctPowerSensorEntityDescription(
         key="g_sync.p_ac[1]",
         name="Inverter Power P2",
         state_class=STATE_CLASS_MEASUREMENT,
+        unit_of_measurement="W",
     ),
     RctPowerSensorEntityDescription(
         key="g_sync.p_ac[2]",
         name="Inverter Power P3",
         state_class=STATE_CLASS_MEASUREMENT,
+        unit_of_measurement="W",
     ),
     RctPowerSensorEntityDescription(
         key="g_sync.p_ac_load_sum_lp",

--- a/custom_components/rct_power/lib/entity.py
+++ b/custom_components/rct_power/lib/entity.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from numbers import Number
 from typing import Any, Dict, List, Optional
 
@@ -132,17 +132,7 @@ class RctPowerEntity(MultiCoordinatorEntity):
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
-        api_responses = (
-            self.get_api_response_by_id(object_id) for object_id in self.object_ids
-        )
-
-        return {
-            "latest_api_responses": [
-                asdict(api_response)
-                for api_response in api_responses
-                if api_response is not None
-            ]
-        }
+        return {}
 
     @property
     def device_class(self):


### PR DESCRIPTION
## :notebook: Summary

This adds the following entities:

- separate grid phases
- insulation resistance

It also fixes the unit on the internal inverter power readings and removes the bulky `latest_api_responses` attribute to preserve storage space.