### PR TITLE
Add calculated entities for power generation

### DIFF
--- a/custom_components/rct_power/__init__.py
+++ b/custom_components/rct_power/__init__.py
@@ -49,20 +49,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hostname=config_entry_data.hostname, port=config_entry_data.port
     )
 
+    frequently_updated_object_ids = list(
+        {
+            object_info.object_id
+            for entity_description in all_entity_descriptions
+            if entity_description.update_priority == EntityUpdatePriority.FREQUENT
+            for object_info in entity_description.object_infos
+        }
+    )
     frequent_update_coordinator = RctPowerDataUpdateCoordinator(
         hass=hass,
         logger=_LOGGER,
         name=f"{DOMAIN} {entry.unique_id} frequent",
         update_interval=timedelta(seconds=config_entry_options.frequent_scan_interval),
-        object_ids=[
-            object_info.object_id
-            for entity_description in all_entity_descriptions
-            if entity_description.update_priority == EntityUpdatePriority.FREQUENT
-            for object_info in entity_description.object_infos
-        ],
+        object_ids=frequently_updated_object_ids,
         client=client,
     )
 
+    infrequently_updated_object_ids = list(
+        {
+            object_info.object_id
+            for entity_description in all_entity_descriptions
+            if entity_description.update_priority == EntityUpdatePriority.INFREQUENT
+            for object_info in entity_description.object_infos
+        }
+    )
     infrequent_update_coordinator = RctPowerDataUpdateCoordinator(
         hass=hass,
         logger=_LOGGER,
@@ -70,26 +81,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         update_interval=timedelta(
             seconds=config_entry_options.infrequent_scan_interval
         ),
-        object_ids=[
-            object_info.object_id
-            for entity_description in all_entity_descriptions
-            if entity_description.update_priority == EntityUpdatePriority.INFREQUENT
-            for object_info in entity_description.object_infos
-        ],
+        object_ids=infrequently_updated_object_ids,
         client=client,
     )
 
+    static_object_ids = list(
+        {
+            object_info.object_id
+            for entity_description in all_entity_descriptions
+            if entity_description.update_priority == EntityUpdatePriority.STATIC
+            for object_info in entity_description.object_infos
+        }
+    )
     static_update_coordinator = RctPowerDataUpdateCoordinator(
         hass=hass,
         logger=_LOGGER,
         name=f"{DOMAIN} {entry.unique_id} static",
         update_interval=timedelta(seconds=config_entry_options.static_scan_interval),
-        object_ids=[
-            object_info.object_id
-            for entity_description in all_entity_descriptions
-            if entity_description.update_priority == EntityUpdatePriority.STATIC
-            for object_info in entity_description.object_infos
-        ],
+        object_ids=static_object_ids,
         client=client,
     )
 

--- a/custom_components/rct_power/lib/entities.py
+++ b/custom_components/rct_power/lib/entities.py
@@ -302,6 +302,17 @@ inverter_sensor_entity_descriptions: List[RctPowerSensorEntityDescription] = [
     ),
     RctPowerSensorEntityDescription(
         get_device_info=get_inverter_device_info,
+        key="dc_conv.dc_conv_struct.p_dc",
+        object_names=[
+            "dc_conv.dc_conv_struct[0].p_dc",
+            "dc_conv.dc_conv_struct[1].p_dc",
+        ],
+        name="All Generators Power",
+        state_class=STATE_CLASS_MEASUREMENT,
+        get_native_value=sum_api_response_values_as_state,
+    ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_inverter_device_info,
         key="dc_conv.start_voltage",
         name="Inverter DC Start Voltage",
         update_priority=EntityUpdatePriority.STATIC,

--- a/custom_components/rct_power/lib/entities.py
+++ b/custom_components/rct_power/lib/entities.py
@@ -10,6 +10,10 @@ from rctclient.registry import REGISTRY
 
 from .device_info_helpers import get_battery_device_info, get_inverter_device_info
 from .entity import EntityUpdatePriority, RctPowerSensorEntityDescription
+from .state_helpers import (
+    get_first_api_reponse_value_as_absolute_state,
+    sum_api_response_values_as_state,
+)
 
 
 def get_matching_names(expression: str):
@@ -548,6 +552,16 @@ inverter_sensor_entity_descriptions: List[RctPowerSensorEntityDescription] = [
     ),
     RctPowerSensorEntityDescription(
         get_device_info=get_inverter_device_info,
+        key="energy.e_grid_feed_absolute_total",
+        unique_id="energy.e_grid_feed_absolute_total",  # to avoid collision
+        object_names=["energy.e_grid_feed_total"],
+        name="Grid Energy Production Absolute Total",
+        update_priority=EntityUpdatePriority.INFREQUENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        get_native_value=get_first_api_reponse_value_as_absolute_state,
+    ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_inverter_device_info,
         key="energy.e_grid_load_day",
         name="Grid Energy Consumption Day",
         update_priority=EntityUpdatePriority.INFREQUENT,
@@ -658,6 +672,15 @@ inverter_sensor_entity_descriptions: List[RctPowerSensorEntityDescription] = [
         update_priority=EntityUpdatePriority.INFREQUENT,
         state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_inverter_device_info,
+        key="energy.e_dc_total",
+        object_names=["energy.e_dc_total[0]", "energy.e_dc_total[1]"],
+        name="All Generators Energy Production Total",
+        update_priority=EntityUpdatePriority.INFREQUENT,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        get_native_value=sum_api_response_values_as_state,
+    ),
 ]
 
 fault_sensor_entity_descriptions: List[RctPowerSensorEntityDescription] = [
@@ -671,6 +694,7 @@ fault_sensor_entity_descriptions: List[RctPowerSensorEntityDescription] = [
             "fault[3].flt",
         ],
         name="Faults",
+        unique_id="fault[0].flt",  # for backwards-compatibility
     ),
 ]
 

--- a/custom_components/rct_power/lib/entry.py
+++ b/custom_components/rct_power/lib/entry.py
@@ -22,7 +22,7 @@ class RctPowerConfigEntryData:
         return cls(**config_entry.data)
 
     @classmethod
-    def from_user_input(cls, user_input):
+    def from_user_input(cls, user_input: object):
         valid_user_input = get_schema_for_dataclass(cls)(user_input)
 
         return cls(**valid_user_input)

--- a/custom_components/rct_power/lib/schema_helpers.py
+++ b/custom_components/rct_power/lib/schema_helpers.py
@@ -1,21 +1,21 @@
 from dataclasses import Field, MISSING, fields
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from voluptuous import Optional as OptionalField, Required as RequiredField, Schema
 
 
-def get_key_for_field(field: Field):
+def get_key_for_field(field: Field[Any]):
     if field.default == MISSING:
         return RequiredField(field.name)
 
     return OptionalField(field.name, default=field.default)
 
 
-def get_schema_for_field(field: Field):
+def get_schema_for_field(field: Field[Any]):
     return field.metadata.get("schema_type", field.type)
 
 
-def get_schema_for_dataclass(cls, allow_fields: Optional[List[str]] = None):
+def get_schema_for_dataclass(cls: type, allow_fields: Optional[List[str]] = None):
     return Schema(
         {
             get_key_for_field(field): get_schema_for_field(field)

--- a/custom_components/rct_power/lib/state_helpers.py
+++ b/custom_components/rct_power/lib/state_helpers.py
@@ -1,0 +1,55 @@
+from typing import Optional
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.helpers.typing import StateType
+
+from .api import ApiResponseValue
+from .const import NUMERIC_STATE_DECIMAL_DIGITS
+
+
+def get_first_api_response_value_as_state(
+    entity: SensorEntity,
+    values: list[Optional[ApiResponseValue]],
+) -> StateType:
+    if len(values) <= 0:
+        return None
+
+    return get_api_response_value_as_state(entity=entity, value=values[0])
+
+
+def get_api_response_value_as_state(
+    entity: SensorEntity,
+    value: Optional[ApiResponseValue],
+) -> StateType:
+    if isinstance(value, bytes):
+        return value.hex()
+
+    if isinstance(value, tuple):
+        return None
+
+    if isinstance(value, (int, float)) and entity.native_unit_of_measurement == "%":
+        return round(value * 100, NUMERIC_STATE_DECIMAL_DIGITS)
+
+    if isinstance(value, (int, float)):
+        return round(value, NUMERIC_STATE_DECIMAL_DIGITS)
+
+    return value
+
+
+def get_first_api_reponse_value_as_absolute_state(
+    entity: SensorEntity,
+    values: list[Optional[ApiResponseValue]],
+) -> StateType:
+    value = get_first_api_response_value_as_state(entity=entity, values=values)
+
+    if isinstance(value, (int, float)):
+        return abs(value)
+
+    return value
+
+
+def sum_api_response_values_as_state(
+    entity: SensorEntity,
+    values: list[Optional[ApiResponseValue]],
+) -> StateType:
+    return sum(value for value in values if isinstance(value, (int, float)))


### PR DESCRIPTION
## :memo: Summary

This adds three new entities that are calculated from the measurements:

- `"Grid Energy Production Absolute Total"`, which is the absolute value of the energy fed into the grid for usage with the energy dashboard
- `"All Generators Energy Production Total"`, which is the sum of the energy produced by generators A and B for simpler use in the energy dashboard
- `"All Generators Power"`, which is the sum of the instantaneous power of generators A and B

closes #91
closes #119

## :female_detective: Implementation notes

The following changes were made in order to allow for multiple (calculated) entities based on the same set of object ids:

- The unique id of each entity now includes all object ids it's derived from.
- The entity description now has an optional `unique_id` override that allows for a stable entity identity even when the general unique id derivation has changed.