### PR TITLE
Add sensor for grid frequency without power switch

### DIFF
--- a/custom_components/rct_power/lib/const.py
+++ b/custom_components/rct_power/lib/const.py
@@ -44,6 +44,7 @@ If you have any issues with this you need to open an issue here:
 """
 
 NUMERIC_STATE_DECIMAL_DIGITS = 1
+FREQUENCY_STATE_DECIMAL_DIGITS = 3
 
 
 class EntityUpdatePriority(Enum):

--- a/custom_components/rct_power/lib/entities.py
+++ b/custom_components/rct_power/lib/entities.py
@@ -439,6 +439,12 @@ inverter_sensor_entity_descriptions: List[RctPowerSensorEntityDescription] = [
     ),
     RctPowerSensorEntityDescription(
         get_device_info=get_inverter_device_info,
+        key="grid_pll[0].f",
+        name="Grid Frequency",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_inverter_device_info,
         key="rb485.f_grid[0]",
         name="Grid Frequency P1",
         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/rct_power/lib/state_helpers.py
+++ b/custom_components/rct_power/lib/state_helpers.py
@@ -4,7 +4,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.typing import StateType
 
 from .api import ApiResponseValue
-from .const import NUMERIC_STATE_DECIMAL_DIGITS
+from .const import FREQUENCY_STATE_DECIMAL_DIGITS, NUMERIC_STATE_DECIMAL_DIGITS
 
 
 def get_first_api_response_value_as_state(
@@ -29,6 +29,9 @@ def get_api_response_value_as_state(
 
     if isinstance(value, (int, float)) and entity.native_unit_of_measurement == "%":
         return round(value * 100, NUMERIC_STATE_DECIMAL_DIGITS)
+
+    if isinstance(value, (int, float)) and entity.native_unit_of_measurement == "Hz":
+        return round(value, FREQUENCY_STATE_DECIMAL_DIGITS)
 
     if isinstance(value, (int, float)):
         return round(value, NUMERIC_STATE_DECIMAL_DIGITS)


### PR DESCRIPTION
## :memo: Summary

This adds a sensor for the grid frequency that also works for systems without a power switch as requested and implemented by @k3mpaxl.

closes #134 