### PR TITLE
Set minimum required HA version to 2021.12.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "hacs": "1.6.0",
   "domains": ["binary_sensor", "sensor"],
   "iot_class": "Local Polling",
-  "homeassistant": "2021.9.0"
+  "homeassistant": "2021.12.0"
 }


### PR DESCRIPTION
## :memo: Summary

This correctly sets the minimum [Home Assistant Core](https://github.com/home-assistant/core) version to 2021.12.0, because the recent migrations from device class and state class constants to enums are only supported since that version.