### PR TITLE
Round the calculated sum entity values

### DIFF
--- a/custom_components/rct_power/lib/state_helpers.py
+++ b/custom_components/rct_power/lib/state_helpers.py
@@ -55,4 +55,8 @@ def sum_api_response_values_as_state(
     entity: SensorEntity,
     values: list[Optional[ApiResponseValue]],
 ) -> StateType:
-    return sum(value for value in values if isinstance(value, (int, float)))
+    return sum(
+        get_api_response_value_as_state(entity, value)
+        for value in values
+        if isinstance(value, (int, float))
+    )


### PR DESCRIPTION
## :memo: Summary

This fixes a small bug due to which the calculated entity values `All Generators Power` and `All Generators Energy Production Total` were not rounded.