### PR TITLE
Use native_unit_of_measurement to prevent recursion.

### DIFF
--- a/custom_components/rct_power/lib/entity.py
+++ b/custom_components/rct_power/lib/entity.py
@@ -130,8 +130,8 @@ class RctPowerSensorEntity(SensorEntity, RctPowerEntity):
         if device_class := super().device_class:
             return device_class
 
-        if self.unit_of_measurement:
-            return guess_device_class_from_unit(self.unit_of_measurement)
+        if self.native_unit_of_measurement:
+            return guess_device_class_from_unit(self.native_unit_of_measurement)
 
         return None
 


### PR DESCRIPTION
In RctPowerSensorEntity the device_class() method used to use unit_of_measurement() to get the unit of measurement for the entity. This no longer works, as with HA 2022.5.0 this implies a recursion back to unit_of_measurement() within the HA device_class() method to figure out if the entity is temperature based.
Thus using native_unit_of_measurement() instead.