### PR TITLE
Remove extra manifest entries

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
   "name": "RCT Power",
   "hacs": "1.6.0",
-  "domains": ["binary_sensor", "sensor"],
-  "iot_class": "Local Polling",
   "homeassistant": "2021.12.0"
 }


### PR DESCRIPTION
## :memo: Summary

This attempts to fix the HACS action linting step by remove extraneous entries from the `hacs.json` manifest file.