### PR TITLE
Fix documentation and issue tracker links in the manifest

### DIFF
--- a/custom_components/rct_power/manifest.json
+++ b/custom_components/rct_power/manifest.json
@@ -1,8 +1,8 @@
 {
   "domain": "rct_power",
   "name": "RCT Power",
-  "documentation": "https://github.com/weltenwort/rct-power",
-  "issue_tracker": "https://github.com/weltenwort/rct-power/issues",
+  "documentation": "https://github.com/weltenwort/home-assistant-rct-power-integration",
+  "issue_tracker": "https://github.com/weltenwort/home-assistant-rct-power-integration/issues",
   "iot_class": "local_polling",
   "dependencies": [],
   "config_flow": true,


### PR DESCRIPTION
## :memo: Summary

This fixes the links to the documentation and issue tracker in the component manifest file.

closes #278 