### PR TITLE
Avoid caching of late properties

### DIFF
--- a/custom_components/rct_power/lib/entity.py
+++ b/custom_components/rct_power/lib/entity.py
@@ -117,7 +117,7 @@ class RctPowerEntity(MultiCoordinatorEntity):
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         return {}
 
-    @cached_property
+    @property
     def device_info(self):
         return self.entity_description.get_device_info(self)
 
@@ -125,7 +125,7 @@ class RctPowerEntity(MultiCoordinatorEntity):
 class RctPowerSensorEntity(SensorEntity, RctPowerEntity):
     entity_description: "RctPowerSensorEntityDescription"  # pyright: ignore [reportIncompatibleVariableOverride]
 
-    @cached_property
+    @property
     def device_class(self):
         """Return the device class of the sensor."""
         if device_class := super().device_class:


### PR DESCRIPTION
## :memo: Summary

This undoes some of the device caching that was introduced with #335 for properties that are read from the remote response. Depending on the start-up timing the device was not properly named, because the remote response hadn't been received yet.