### PR TITLE
Speed up CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,6 +50,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          setup-python-dependencies: false
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
## :memo: Summary

This speeds up the CodeQL workflow by not installing all project python deps during initialization. This would have been the default if this was a newer repo and follows the official recommendation of the CodeQL action.