### PR TITLE
Remove async_timeout dependency

### DIFF
--- a/custom_components/rct_power/lib/api.py
+++ b/custom_components/rct_power/lib/api.py
@@ -1,14 +1,14 @@
 """Sample API Client."""
 
+import asyncio
 import logging
 import struct
-from asyncio import StreamReader, StreamWriter, TimeoutError, open_connection
+from asyncio import StreamReader, StreamWriter, open_connection
 from asyncio.locks import Lock
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple, TypeVar, Union
 
-import async_timeout
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from rctclient.exceptions import FrameCRCMismatch, FrameLengthExceeded, InvalidCommand
 from rctclient.frame import ReceiveFrame, SendFrame
@@ -87,7 +87,7 @@ class RctPowerApiClient:
 
     async def async_get_data(self, object_ids: List[int]) -> RctPowerData:
         async with self._connection_lock:
-            async with async_timeout.timeout(CONNECTION_TIMEOUT):
+            async with asyncio.timeout(CONNECTION_TIMEOUT):
                 reader, writer = await open_connection(
                     host=self._hostname, port=self._port
                 )
@@ -117,7 +117,7 @@ class RctPowerApiClient:
         request_time = datetime.now()
 
         try:
-            async with async_timeout.timeout(READ_TIMEOUT):
+            async with asyncio.timeout(READ_TIMEOUT):
                 await writer.drain()
                 writer.write(read_command_frame.data)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -4611,4 +4611,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<3.14"
-content-hash = "e31c800433a8356edf6ac520a73e4635344e71ff4016df23d11266330895ddc7"
+content-hash = "fb0dadb3e7c74395bc2f2fc332549a344bdcffef37d77c39be40794474e9745a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-async_timeout = "^5.0.1"
 homeassistant = "^2025.2.5"
 python = ">=3.13,<3.14"
 rctclient = "^0.0.3"


### PR DESCRIPTION
In Python 3.11 `asyncio.timeout` was added and `asyncio.TimeoutError` became an alias for `builtins.TimeoutError`.

https://docs.python.org/3/library/asyncio-task.html#asyncio.timeout
https://docs.python.org/3/library/asyncio-exceptions.html#asyncio.TimeoutError