### PR TITLE
Fix pytest warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -25,12 +25,14 @@ def skip_notifications_fixture():
         yield
 
 
-# This fixture, when used, will result in calls to async_get_data to return None. To have the call
-# return a value, we would add the `return_value=<VALUE_TO_RETURN>` parameter to the patch call.
+# This fixture, when used, will result in calls to async_get_data to return None.
 @pytest.fixture(name="bypass_get_data")
 def bypass_get_data_fixture():
     """Skip calls to get data from API."""
-    with patch("custom_components.rct_power.RctPowerApiClient.async_get_data"):
+    with patch(
+        "custom_components.rct_power.RctPowerApiClient.async_get_data",
+        return_value=None,
+    ):
         yield
 
 


### PR DESCRIPTION
Without the explicit `return_value=None`, `patch` returns an instance of `MagicMock` / `AsyncMock`.
This leads to a lot of warnings. See https://github.com/weltenwort/home-assistant-rct-power-integration/actions/runs/13749071871/job/38447692776#step:6:46