### PR TITLE
Minor improvements for coordinator base class

### DIFF
--- a/custom_components/rct_power/__init__.py
+++ b/custom_components/rct_power/__init__.py
@@ -17,12 +17,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassEntryKey
 
+from .coordinator import RctPowerDataUpdateCoordinator
 from .lib.api import RctPowerApiClient
 from .lib.const import DOMAIN, PLATFORMS, STARTUP_MESSAGE, EntityUpdatePriority
 from .lib.entities import all_entity_descriptions
 from .lib.entity import resolve_object_infos
 from .lib.entry import RctPowerConfigEntryData, RctPowerConfigEntryOptions
-from .lib.update_coordinator import RctPowerDataUpdateCoordinator
 
 SCAN_INTERVAL = timedelta(seconds=30)
 RCT_DATA_KEY: HassEntryKey[RctData] = HassEntryKey(DOMAIN)
@@ -68,7 +68,8 @@ async def async_setup_entry(
     frequent_update_coordinator = RctPowerDataUpdateCoordinator(
         hass=hass,
         logger=_LOGGER,
-        name=f"{DOMAIN} {entry.unique_id} frequent",
+        entry=entry,
+        name_suffix="frequent",
         update_interval=timedelta(seconds=config_entry_options.frequent_scan_interval),
         object_ids=frequently_updated_object_ids,
         client=client,
@@ -85,7 +86,8 @@ async def async_setup_entry(
     infrequent_update_coordinator = RctPowerDataUpdateCoordinator(
         hass=hass,
         logger=_LOGGER,
-        name=f"{DOMAIN} {entry.unique_id} infrequent",
+        entry=entry,
+        name_suffix="infrequent",
         update_interval=timedelta(
             seconds=config_entry_options.infrequent_scan_interval
         ),
@@ -104,7 +106,8 @@ async def async_setup_entry(
     static_update_coordinator = RctPowerDataUpdateCoordinator(
         hass=hass,
         logger=_LOGGER,
-        name=f"{DOMAIN} {entry.unique_id} static",
+        entry=entry,
+        name_suffix="static",
         update_interval=timedelta(seconds=config_entry_options.static_scan_interval),
         object_ids=static_object_ids,
         client=client,

--- a/custom_components/rct_power/coordinator.py
+++ b/custom_components/rct_power/coordinator.py
@@ -3,29 +3,38 @@ from __future__ import annotations
 from datetime import timedelta
 from logging import Logger
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .api import ApiResponseValue, RctPowerApiClient, RctPowerData, ValidApiResponse
+from .lib.api import ApiResponseValue, RctPowerApiClient, RctPowerData, ValidApiResponse
+from .lib.const import DOMAIN
 
 
 class RctPowerDataUpdateCoordinator(DataUpdateCoordinator[RctPowerData]):
     """Class to manage fetching data from the rct power inverter API."""
 
+    config_entry: ConfigEntry
+
     def __init__(
         self,
         hass: HomeAssistant,
-        name: str,
         logger: Logger,
+        entry: ConfigEntry,
+        *,
+        name_suffix: str,
         client: RctPowerApiClient,
         object_ids: list[int],
         update_interval: timedelta | None = None,
     ) -> None:
         self.client = client
         self.object_ids = object_ids
-
         super().__init__(
-            hass=hass, logger=logger, name=name, update_interval=update_interval
+            hass=hass,
+            config_entry=entry,
+            logger=logger,
+            name=f"{DOMAIN} {entry.unique_id} {name_suffix}",
+            update_interval=update_interval,
         )
 
     def get_latest_response(self, object_id: int):

--- a/custom_components/rct_power/lib/entity.py
+++ b/custom_components/rct_power/lib/entity.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.typing import UNDEFINED, StateType, UndefinedType
 from rctclient.registry import REGISTRY, ObjectInfo
 
+from ..coordinator import RctPowerDataUpdateCoordinator
 from .api import (
     ApiResponse,
     ApiResponseValue,
@@ -32,7 +33,6 @@ from .state_helpers import (
     get_api_response_values_as_bitfield,
     get_first_api_response_value_as_state,
 )
-from .update_coordinator import RctPowerDataUpdateCoordinator
 
 
 class RctPowerEntity(MultiCoordinatorEntity):

--- a/custom_components/rct_power/lib/multi_coordinator_entity.py
+++ b/custom_components/rct_power/lib/multi_coordinator_entity.py
@@ -5,7 +5,7 @@ from asyncio.tasks import gather
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 
-from .update_coordinator import RctPowerDataUpdateCoordinator
+from ..coordinator import RctPowerDataUpdateCoordinator
 
 
 class MultiCoordinatorEntity(Entity):


### PR DESCRIPTION
- The coordinator should pass the config entry explicitly. Relying on the `DataUpdateCoordinator` base class will soon be deprecated.
- The coordinator base class should be stored in `<integration>/coordinator.py`
https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/common-modules/