### PR TITLE
Improve logging config

### DIFF
--- a/custom_components/rct_power/config_flow.py
+++ b/custom_components/rct_power/config_flow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from logging import Logger, getLogger
 
 from homeassistant import config_entries
 from homeassistant.core import callback
@@ -12,8 +11,6 @@ from voluptuous.error import MultipleInvalid
 from .lib.api import RctPowerApiClient
 from .lib.const import DOMAIN
 from .lib.entry import RctPowerConfigEntryData, RctPowerConfigEntryOptions, get_title
-
-_LOGGER: Logger = getLogger(__package__)
 
 
 class RctPowerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/rct_power/const.py
+++ b/custom_components/rct_power/const.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+import logging
+
+LOGGER = logging.getLogger(__package__)

--- a/custom_components/rct_power/coordinator.py
+++ b/custom_components/rct_power/coordinator.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from logging import Logger
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from .const import LOGGER
 from .lib.api import ApiResponseValue, RctPowerApiClient, RctPowerData, ValidApiResponse
 from .lib.const import DOMAIN
 
@@ -19,7 +19,6 @@ class RctPowerDataUpdateCoordinator(DataUpdateCoordinator[RctPowerData]):
     def __init__(
         self,
         hass: HomeAssistant,
-        logger: Logger,
         entry: ConfigEntry,
         *,
         name_suffix: str,
@@ -32,7 +31,7 @@ class RctPowerDataUpdateCoordinator(DataUpdateCoordinator[RctPowerData]):
         super().__init__(
             hass=hass,
             config_entry=entry,
-            logger=logger,
+            logger=LOGGER,
             name=f"{DOMAIN} {entry.unique_id} {name_suffix}",
             update_interval=update_interval,
         )

--- a/custom_components/rct_power/init_test.py
+++ b/custom_components/rct_power/init_test.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.rct_power import RctData, async_setup_entry, async_unload_entry
+from custom_components.rct_power import RctData, async_setup_entry
 from custom_components.rct_power.lib.const import DOMAIN
 from custom_components.rct_power.lib.entry import RctPowerConfigEntryData
 
@@ -35,18 +35,12 @@ async def test_setup_unload_and_reload_entry(hass: HomeAssistant) -> None:
     # call, no code from custom_components/rct_power/api.py actually runs.
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert DOMAIN in hass.data
     assert isinstance(config_entry.runtime_data, RctData)
 
     # Reload the entry and assert that the data from above is still there
     assert await hass.config_entries.async_reload(config_entry.entry_id)
     await hass.async_block_till_done()
     assert isinstance(config_entry.runtime_data, RctData)
-
-    # Unload the entry and verify that the data has been removed
-    assert await async_unload_entry(hass, config_entry)
-    await hass.async_block_till_done()
-    assert DOMAIN not in hass.data
 
 
 @pytest.mark.usefixtures("error_on_get_data")

--- a/custom_components/rct_power/lib/const.py
+++ b/custom_components/rct_power/lib/const.py
@@ -10,8 +10,6 @@ DOMAIN = "rct_power"
 DOMAIN_DATA = f"{DOMAIN}_data"
 VERSION = "0.14.1"
 
-ISSUE_URL = "https://github.com/weltenwort/home-assistant-rct-power-integration/issues"
-
 # Inverter
 INVERTER_MODEL = "RCT Power Storage"
 
@@ -34,16 +32,6 @@ CONF_SCAN_INTERVAL = "scan_interval"
 
 # Defaults
 DEFAULT_NAME = DOMAIN
-
-STARTUP_MESSAGE = f"""
--------------------------------------------------------------------
-{NAME}
-Version: {VERSION}
-This is a custom integration!
-If you have any issues with this you need to open an issue here:
-{ISSUE_URL}
--------------------------------------------------------------------
-"""
 
 NUMERIC_STATE_DECIMAL_DIGITS = 1
 FREQUENCY_STATE_DECIMAL_DIGITS = 3


### PR DESCRIPTION
- Store logger in a central location -> `<integration>/const.py` (I plan on moving more constants there from `api/const.py` in the future)
- Remove unnecessary startup message (see https://github.com/weltenwort/home-assistant-rct-power-integration/pull/442#discussion_r2008829623)

~_Depends on #454 to be merged first._~