### PR TITLE
Remove unused async_setup function

### DIFF
--- a/custom_components/rct_power/__init__.py
+++ b/custom_components/rct_power/__init__.py
@@ -12,7 +12,6 @@ from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassEntryKey
 
 from .coordinator import RctPowerDataUpdateCoordinator
@@ -31,11 +30,6 @@ type RctConfigEntry = ConfigEntry[RctData]
 @dataclass
 class RctData:
     update_coordinators: dict[EntityUpdatePriority, RctPowerDataUpdateCoordinator]
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType):
-    """Set up this integration using YAML is not supported."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: RctConfigEntry) -> bool:


### PR DESCRIPTION
Yaml setup isn't supported, so we should remove `async_setup`.
Hassfest does even have a check for it. See the annotation on any recent CI run, e.g.
https://github.com/weltenwort/home-assistant-rct-power-integration/actions/runs/14145525178

_Technically this could break setups which have used `rct_power:` in their configs. However, as it never worked to begin with, it might be fine to remove without proper deprecation._