### PR TITLE
Fix ConfigEntry not working

### DIFF
--- a/custom_components/rct_power/lib/entry.py
+++ b/custom_components/rct_power/lib/entry.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any, Self
 


### PR DESCRIPTION
Fixes #466

At the moment the dataclass var types are used to calculate the corresponding class for the schema validation. With the addition of `from __future__ import annotations`, all annotations were converted to strings causing the ConfigFlow to break.

I do plan on refactoring the ConfigFlow handling in a future PR as I believe it's overly complicated for what it needs to do.