### PR TITLE
Cleanup coordinator setup

### DIFF
--- a/custom_components/rct_power/coordinator.py
+++ b/custom_components/rct_power/coordinator.py
@@ -27,10 +27,10 @@ class RctPowerDataUpdateCoordinator(DataUpdateCoordinator[RctPowerData]):
         hass: HomeAssistant,
         entry: ConfigEntry,
         *,
-        name_suffix: str,
         client: RctPowerApiClient,
+        name_suffix: str,
         object_ids: list[int],
-        update_interval: timedelta | None = None,
+        update_interval: int,
     ) -> None:
         self.client = client
         self.object_ids = object_ids
@@ -39,7 +39,7 @@ class RctPowerDataUpdateCoordinator(DataUpdateCoordinator[RctPowerData]):
             config_entry=entry,
             logger=LOGGER,
             name=f"{DOMAIN} {entry.unique_id} {name_suffix}",
-            update_interval=update_interval,
+            update_interval=timedelta(seconds=update_interval),
         )
 
     def get_latest_response(


### PR DESCRIPTION
- Add a new helper function to collect object_ids for an update_priority to reduce code duplication.
- Move the `timedelta` conversion to the UpdateCoordinator class.
- Reorder the coordinator arguments.