### PR TITLE
Add quality scale template

### DIFF
--- a/custom_components/rct_power/quality_scale.yaml
+++ b/custom_components/rct_power/quality_scale.yaml
@@ -1,0 +1,62 @@
+# https://developers.home-assistant.io/docs/core/integration-quality-scale/
+
+rules:
+  # Bronze
+  action-setup: todo
+  appropriate-polling: todo
+  brands: todo
+  common-modules: todo
+  config-flow-test-coverage: todo
+  config-flow: todo
+  dependency-transparency: todo
+  docs-actions: todo
+  docs-high-level-description: todo
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  entity-event-setup: todo
+  entity-unique-id: todo
+  has-entity-name: todo
+  runtime-data: todo
+  test-before-configure: todo
+  test-before-setup: todo
+  unique-config-entry: todo
+
+  # Silver
+  action-exceptions: todo
+  config-entry-unloading: todo
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable: todo
+  integration-owner: todo
+  log-when-unavailable: todo
+  parallel-updates: todo
+  reauthentication-flow: todo
+  test-coverage: todo
+
+  # Gold
+  devices: todo
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: todo
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo


### PR DESCRIPTION
The basic quality scale template. We can check off things as we go. Some might even have been done already.
https://developers.home-assistant.io/docs/core/integration-quality-scale/