### PR TITLE
Change pre-commit mirror for prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.7.4
     hooks:
       - id: prettier
 


### PR DESCRIPTION
https://github.com/pre-commit/mirrors-prettier was archived a year ago.
Switch to https://github.com/rbubley/mirrors-prettier.

Also update prettier to `3.7.4`.
https://github.com/prettier/prettier/blob/main/CHANGELOG.md