### PR TITLE
added sensors for each entity supported by rctpower_writesupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ depending on your preference.
 | Battery Used Energy                      | Wh   | the cumulative energy consumed from the battery                               |
 | Battery Status                           |      | the current battery status (incomplete)                                       |
 | Next Battery Calibration Date            |      | the date and time of the next planned battery calibration                     |
+| Battery State of Charge Strategy         |      | SOC target selection SOC" = 0x00, "Constant" = 0x01, "External" = 0x02, "Middle battery voltage" = 0x03, "Internal" = 0x04, "Schedule" = 0x05 |
+| Battery State of Charge force set        | %    | Force SOC target (used on external strategy)                                  |
+| Trigger for charging to SOC_min          | %    | SOC min maintenance charge (below load is forced)                             |
+| Charging power to reach SOC target       | W    | Maintenance charge power (to reach SOC_min when below)                        |
+| Battery target power                     | W    | Battery target power (positive = discharge)                                   |
+| Max battery to grid power                | W    | Max. battery to grid power (unload to grid until target SOC is reached)       |
 
 ### Household consumers and producers
 
@@ -174,6 +180,8 @@ depending on your preference.
 | Core Temperature                                | °C   | the instantaneous temperature of the invertor core              |
 | Heat Sink Temperature                           | °C   | the instantaneous temperature of the invertor heat sink         |
 | Heat Sink (battery actuator) Temperature        | °C   | the instantaneous temperature of the battery actuator heat sink |
+| External power reduction                        | %    | External power reduction based on solar plant peak power        |
+| Use Grid Power                                  |      | Utilize external Inverter energy                                |
 
 ## Contributions are welcome!
 

--- a/README.md
+++ b/README.md
@@ -117,29 +117,29 @@ depending on your preference.
 
 ### Battery
 
-| Entity name                              | Unit | Description                                                                   |
-| ---------------------------------------- | ---- | ----------------------------------------------------------------------------- |
-| Battery Power                            | W    | the instantaneous power consumed from (`> 0`) or fed into (`< 0`) the battery |
-| Battery Current                          | A    | the instantaneous current flowing from or to the battery                      |
-| Battery Voltage                          | V    | the instantaneous voltage of the battery                                      |
-| Battery Temperature                      | °C   | the instantaneous temperature of the battery                                  |
-| Battery Cycles                           |      | the recorded full charge/discharge cycles of the battery                      |
-| Battery State of Charge                  | %    | the instantaneous state of charge of the battery                              |
-| Battery State of Charge Target           | %    | the state of charge of the battery aimed for by the system                    |
-| Battery Minimum State of Charge          | %    | the configured minimum state of charge of the battery for regular operation   |
-| Battery Minimum State of Charge (island) | %    | the minimum state of charge of the battery to maintain as an island backup    |
-| Battery Maximum State of Charge          | %    | the maximum state of charge of the battery to aim for to improve battery life |
-| Battery State of Health                  | %    | the estimated state of health of the battery                                  |
-| Battery Stored Energy                    | Wh   | the cumulative energy fed into the battery                                    |
-| Battery Used Energy                      | Wh   | the cumulative energy consumed from the battery                               |
-| Battery Status                           |      | the current battery status (incomplete)                                       |
-| Next Battery Calibration Date            |      | the date and time of the next planned battery calibration                     |
-| Battery State of Charge Strategy         |      | SOC target selection SOC" = 0x00, "Constant" = 0x01, "External" = 0x02, "Middle battery voltage" = 0x03, "Internal" = 0x04, "Schedule" = 0x05 |
-| Battery State of Charge force set        | %    | Force SOC target (used on external strategy)                                  |
-| Trigger for charging to SOC_min          | %    | SOC min maintenance charge (below load is forced)                             |
-| Charging power to reach SOC target       | W    | Maintenance charge power (to reach SOC_min when below)                        |
-| Battery target power                     | W    | Battery target power (positive = discharge)                                   |
-| Max battery to grid power                | W    | Max. battery to grid power (unload to grid until target SOC is reached)       |
+| Entity name                              | Unit | Description                                                                                                                  |
+| ---------------------------------------- | ---- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Battery Power                            | W    | the instantaneous power consumed from (`> 0`) or fed into (`< 0`) the battery                                                |
+| Battery Current                          | A    | the instantaneous current flowing from or to the battery                                                                     |
+| Battery Voltage                          | V    | the instantaneous voltage of the battery                                                                                     |
+| Battery Temperature                      | °C   | the instantaneous temperature of the battery                                                                                 |
+| Battery Cycles                           |      | the recorded full charge/discharge cycles of the battery                                                                     |
+| Battery State of Charge                  | %    | the instantaneous state of charge of the battery                                                                             |
+| Battery State of Charge Target           | %    | the state of charge of the battery aimed for by the system                                                                   |
+| Battery Minimum State of Charge          | %    | the configured minimum state of charge of the battery for regular operation                                                  |
+| Battery Minimum State of Charge (island) | %    | the minimum state of charge of the battery to maintain as an island backup                                                   |
+| Battery Maximum State of Charge          | %    | the maximum state of charge of the battery to aim for to improve battery life                                                |
+| Battery State of Health                  | %    | the estimated state of health of the battery                                                                                 |
+| Battery Stored Energy                    | Wh   | the cumulative energy fed into the battery                                                                                   |
+| Battery Used Energy                      | Wh   | the cumulative energy consumed from the battery                                                                              |
+| Battery Status                           |      | the current battery status (incomplete)                                                                                      |
+| Next Battery Calibration Date            |      | the date and time of the next planned battery calibration                                                                    |
+| Battery State of Charge Strategy         |      | SOC target selection "SOC" = 0, "Constant" = 1, "External" = 2, "Middle battery voltage" = 3, "Internal" = 4, "Schedule" = 5 |
+| Battery State of Charge force set        | %    | Force SOC target (used on external strategy)                                                                                 |
+| Trigger for charging to SOC_min          | %    | SOC min maintenance charge (below load is forced)                                                                            |
+| Charging power to reach SOC target       | W    | Maintenance charge power (to reach SOC_min when below)                                                                       |
+| Battery target power                     | W    | Battery target power (positive = discharge)                                                                                  |
+| Max battery to grid power                | W    | Max. battery to grid power (unload to grid until target SOC is reached)                                                      |
 
 ### Household consumers and producers
 

--- a/custom_components/rct_power/lib/entities.py
+++ b/custom_components/rct_power/lib/entities.py
@@ -229,6 +229,53 @@ battery_sensor_entity_descriptions: list[RctPowerSensorEntityDescription] = [
         device_class=SensorDeviceClass.TIMESTAMP,
         get_native_value=get_first_api_response_value_as_timestamp,
     ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_battery_device_info,
+        key="power_mng.soc_strategy",
+        name="Battery State of Charge Strategy",
+        update_priority=EntityUpdatePriority.INFREQUENT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_battery_device_info,
+        key="power_mng.soc_target_set",
+        name="Battery State of Charge force set",
+        update_priority=EntityUpdatePriority.FREQUENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="%",
+    ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_battery_device_info,
+        key="power_mng.soc_charge",
+        name="Battery trigger for charging to SOC_min",
+        update_priority=EntityUpdatePriority.FREQUENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="%",
+    ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_battery_device_info,
+        key="power_mng.soc_charge_power",
+        name="Battery Charging power to reach SOC target",
+        update_priority=EntityUpdatePriority.FREQUENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="W",
+    ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_battery_device_info,
+        key="power_mng.battery_power_extern",
+        name="Battery target power",
+        update_priority=EntityUpdatePriority.FREQUENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="W",
+    ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_battery_device_info,
+        key="p_rec_lim[1]",
+        name="Battery Max to grid power",
+        update_priority=EntityUpdatePriority.FREQUENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="W",
+    ),
 ]
 
 inverter_sensor_entity_descriptions: list[RctPowerSensorEntityDescription] = [
@@ -748,6 +795,19 @@ inverter_sensor_entity_descriptions: list[RctPowerSensorEntityDescription] = [
         name="External Generator S0 Power",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="W",
+    ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_inverter_device_info,
+        key="buf_v_control.power_reduction",
+        name="External power reduction",
+        update_priority=EntityUpdatePriority.FREQUENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="%",
+    ),
+    RctPowerSensorEntityDescription(
+        get_device_info=get_inverter_device_info,
+        key="power_mng.use_grid_power_enable",
+        name="Use Grid Power",
     ),
 ]
 


### PR DESCRIPTION
# Improvement

This plugin has no support for setting inverter parameters, the [rctpower_writesupport](https://github.com/do-gooder/rctpower_writesupport) project has. To create input widget which can be used in automations and dashboards, it would help a lot, to have all the entities, which can be changed, also as sensor. I've included them in this pull request.

## How to use it?
Take a look into [000_rct_input_widgets_package.yaml](https://github.com/ManfredTremmel/home_assistant_config/blob/main/packages/000_rct_input_widgets_package.yaml), I've defined all of them there.

## Example from my Dashboard using it

<img width="1021" height="719" alt="image" src="https://github.com/user-attachments/assets/04206484-41ef-4240-9b37-d3dc4302e1ad" />

In the two lower lines, `number.number_rct_power_storage_battery_minimum_soc`, `number.number_rct_power_storage_battery_maximum_soc`, `switch.switch_rct_power_storage_use_grid_power` and `number.number_rct_power_storage_battery_to_grid_power` are added as simple cards and allow to change lower and upper SOC limit of the battery, the usage of my second inverter to fill the battery and the limitation of the power to grid unload. All this stuff is also used in automations, makes it much easier and saver to set a number field (with limits) then sending a string by the `pyscript.rct_ha_call` script.