### PR TITLE
Update requirement of rctclient to 0.0.6 in manifest.json

### DIFF
--- a/custom_components/rct_power/manifest.json
+++ b/custom_components/rct_power/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/weltenwort/home-assistant-rct-power-integration",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/weltenwort/home-assistant-rct-power-integration/issues",
-  "requirements": ["rctclient==0.0.3"],
+  "requirements": ["rctclient==0.0.6"],
   "version": "0.14.2"
 }


### PR DESCRIPTION
Latest version of rctclient on pypy.org is 0.0.6. Using 0.0.3 leads to an error during setup of rct power integration.

see https://github.com/weltenwort/home-assistant-rct-power-integration/issues/501#issuecomment-4435377184