### PR TITLE
prefer smart meter voltage and otherwise expose inverter voltage

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ depending on your preference.
 | Grid Frequency P1/P2/P3                      | Hz   | the instantaneous grid frequency on phase 1/2/3                                  |
 | Grid Power                                   | W    | the instantaneous power consumed from (`> 0`) or fed into (`< 0`) the grid       |
 | Grid Power P1/P2/P3                          | W    | the instantaneous power consumed from or fed into the grid on phase 1/2/3        |
-| Grid Voltage P1/P2/P3                        | W    | the instantaneous grid voltage on phase 1/2/3                                    |
+| Grid Voltage P1/P2/P3                        | V    | the instantaneous grid voltage on phase 1/2/3                                    |
 | Grid Energy Consumption Day/Month/Year/Total | Wh   | the cumulative energy consumed from the grid                                     |
 | Grid Energy Production Day/Month/Year/Total  | Wh   | the cumulative energy fed into the grid                                          |
 | Grid Energy Production Absolute Total        | kWh  | the absolute value of the cumulative energy fed into the grid since installation |

--- a/custom_components/rct_power/lib/entities.py
+++ b/custom_components/rct_power/lib/entities.py
@@ -19,6 +19,53 @@ from .state_helpers import (
     sum_api_response_values_as_state,
 )
 
+GRID_VOLTAGE_SMARTMETER_OBJECT_NAMES = [
+    "rb485.u_l_grid[0]",
+    "rb485.u_l_grid[1]",
+    "rb485.u_l_grid[2]",
+]
+GRID_VOLTAGE_INVERTER_OBJECT_NAMES = [
+    "g_sync.u_l_rms[0]",
+    "g_sync.u_l_rms[1]",
+    "g_sync.u_l_rms[2]",
+]
+
+
+def get_grid_voltage_sensor_entity_descriptions(
+    smartmeter_voltage_available: list[bool],
+) -> list[RctPowerSensorEntityDescription]:
+    """Prefer smart meter voltage and otherwise expose inverter voltage."""
+    return [
+        RctPowerSensorEntityDescription(
+            get_device_info=get_inverter_device_info,
+            key=smartmeter_object_name
+            if smartmeter_available
+            else inverter_object_name,
+            # Preserve the former smart meter entity ID during migration.
+            unique_id=(
+                None
+                if smartmeter_available
+                else str(REGISTRY.get_by_name(smartmeter_object_name).object_id)
+            ),
+            name=("Grid" if smartmeter_available else "Inverter Grid")
+            + f" Voltage P{phase}",
+            state_class=SensorStateClass.MEASUREMENT,
+        )
+        for phase, (
+            smartmeter_available,
+            smartmeter_object_name,
+            inverter_object_name,
+        ) in enumerate(
+            zip(
+                smartmeter_voltage_available,
+                GRID_VOLTAGE_SMARTMETER_OBJECT_NAMES,
+                GRID_VOLTAGE_INVERTER_OBJECT_NAMES,
+                strict=True,
+            ),
+            start=1,
+        )
+    ]
+
 
 def get_matching_names(expression: str) -> list[str]:
     compiled_expression = re.compile(expression)
@@ -230,6 +277,7 @@ battery_sensor_entity_descriptions: list[RctPowerSensorEntityDescription] = [
         get_native_value=get_first_api_response_value_as_timestamp,
     ),
 ]
+
 
 inverter_sensor_entity_descriptions: list[RctPowerSensorEntityDescription] = [
     RctPowerSensorEntityDescription(
@@ -751,6 +799,7 @@ inverter_sensor_entity_descriptions: list[RctPowerSensorEntityDescription] = [
     ),
 ]
 
+
 bitfield_sensor_entity_descriptions: list[RctPowerBitfieldSensorEntityDescription] = [
     RctPowerBitfieldSensorEntityDescription(
         get_device_info=get_inverter_device_info,
@@ -778,6 +827,8 @@ bitfield_sensor_entity_descriptions: list[RctPowerBitfieldSensorEntityDescriptio
 sensor_entity_descriptions = [
     *battery_sensor_entity_descriptions,
     *inverter_sensor_entity_descriptions,
+    # Poll both sources; setup exposes exactly one voltage entity per phase.
+    *get_grid_voltage_sensor_entity_descriptions([False, False, False]),
     *bitfield_sensor_entity_descriptions,
 ]
 

--- a/custom_components/rct_power/lib/entities.py
+++ b/custom_components/rct_power/lib/entities.py
@@ -19,12 +19,12 @@ from .state_helpers import (
     sum_api_response_values_as_state,
 )
 
-GRID_VOLTAGE_SMARTMETER_OBJECT_NAMES = [
+grid_voltage_smartmeter_object_names = [
     "rb485.u_l_grid[0]",
     "rb485.u_l_grid[1]",
     "rb485.u_l_grid[2]",
 ]
-GRID_VOLTAGE_INVERTER_OBJECT_NAMES = [
+grid_voltage_inverter_object_names = [
     "g_sync.u_l_rms[0]",
     "g_sync.u_l_rms[1]",
     "g_sync.u_l_rms[2]",
@@ -58,8 +58,8 @@ def get_grid_voltage_sensor_entity_descriptions(
         ) in enumerate(
             zip(
                 smartmeter_voltage_available,
-                GRID_VOLTAGE_SMARTMETER_OBJECT_NAMES,
-                GRID_VOLTAGE_INVERTER_OBJECT_NAMES,
+                grid_voltage_smartmeter_object_names,
+                grid_voltage_inverter_object_names,
                 strict=True,
             ),
             start=1,

--- a/custom_components/rct_power/sensor.py
+++ b/custom_components/rct_power/sensor.py
@@ -10,10 +10,10 @@ from rctclient.registry import REGISTRY
 
 from . import RctConfigEntry
 from .lib.entities import (
-    GRID_VOLTAGE_SMARTMETER_OBJECT_NAMES,
     battery_sensor_entity_descriptions,
     bitfield_sensor_entity_descriptions,
     get_grid_voltage_sensor_entity_descriptions,
+    grid_voltage_smartmeter_object_names,
     inverter_sensor_entity_descriptions,
 )
 from .lib.entity import RctPowerBitfieldSensorEntity, RctPowerSensorEntity
@@ -54,7 +54,7 @@ async def async_setup_entry(
             entity_description=entity_description,
         )
         for entity_description in inverter_sensor_entity_descriptions
-        if entity_description.key not in GRID_VOLTAGE_SMARTMETER_OBJECT_NAMES
+        if entity_description.key not in grid_voltage_smartmeter_object_names
     ]
 
     grid_voltage_sensor_entities = [
@@ -66,7 +66,7 @@ async def async_setup_entry(
         for entity_description in get_grid_voltage_sensor_entity_descriptions(
             [
                 _has_smartmeter_voltage(entry, object_name)
-                for object_name in GRID_VOLTAGE_SMARTMETER_OBJECT_NAMES
+                for object_name in grid_voltage_smartmeter_object_names
             ]
         )
     ]

--- a/custom_components/rct_power/sensor.py
+++ b/custom_components/rct_power/sensor.py
@@ -6,14 +6,28 @@ from collections.abc import Callable
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
+from rctclient.registry import REGISTRY
 
 from . import RctConfigEntry
 from .lib.entities import (
+    GRID_VOLTAGE_SMARTMETER_OBJECT_NAMES,
     battery_sensor_entity_descriptions,
     bitfield_sensor_entity_descriptions,
+    get_grid_voltage_sensor_entity_descriptions,
     inverter_sensor_entity_descriptions,
 )
 from .lib.entity import RctPowerBitfieldSensorEntity, RctPowerSensorEntity
+
+
+def _has_smartmeter_voltage(entry: RctConfigEntry, object_name: str) -> bool:
+    """Return whether the smart meter reports a non-zero voltage."""
+    object_id = REGISTRY.get_by_name(object_name).object_id
+
+    return any(
+        isinstance(value := coordinator.get_valid_value_or(object_id, 0), (int, float))
+        and value != 0
+        for coordinator in entry.runtime_data.update_coordinators.values()
+    )
 
 
 async def async_setup_entry(
@@ -40,6 +54,21 @@ async def async_setup_entry(
             entity_description=entity_description,
         )
         for entity_description in inverter_sensor_entity_descriptions
+        if entity_description.key not in GRID_VOLTAGE_SMARTMETER_OBJECT_NAMES
+    ]
+
+    grid_voltage_sensor_entities = [
+        RctPowerSensorEntity(
+            coordinators=list(data.update_coordinators.values()),
+            config_entry=entry,
+            entity_description=entity_description,
+        )
+        for entity_description in get_grid_voltage_sensor_entity_descriptions(
+            [
+                _has_smartmeter_voltage(entry, object_name)
+                for object_name in GRID_VOLTAGE_SMARTMETER_OBJECT_NAMES
+            ]
+        )
     ]
 
     bitfield_sensor_entities = [
@@ -55,6 +84,7 @@ async def async_setup_entry(
         [
             *battery_sensor_entities,
             *inverter_sensor_entities,
+            *grid_voltage_sensor_entities,
             *bitfield_sensor_entities,
         ]
     )


### PR DESCRIPTION
A friend is using the RCT power sensor 50 and that one is not providing any smart meter voltage measurements. 
My idea is to add a fallback to the inverter voltage. I am not 100% sure if that is a good idea. Please find review and merge that PR. Thanks.  